### PR TITLE
Add code-block directives

### DIFF
--- a/docs/accessing_data.rst
+++ b/docs/accessing_data.rst
@@ -1,6 +1,8 @@
 Accessing Data in The Cloud
 ===========================
-Because of its Zarr format, individual CMIP6 data stores can be accessed using `xarray <https://xarray.pydata.org/en/stable/>`_::
+Because of its Zarr format, individual CMIP6 data stores can be accessed using `xarray <https://xarray.pydata.org/en/stable/>`_:
+
+.. code-block:: python
 
   import fsspec
   import xarray as xr
@@ -14,7 +16,9 @@ When all relevant data stores have been discovered, they can then be merged and 
 
 Loading An ESM Collection
 -------------------------
-To load an Earth System Model (ESM) collection with `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, the user must provide a valid ESM data catalog as input::
+To load an Earth System Model (ESM) collection with `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, the user must provide a valid ESM data catalog as input:
+
+.. code-block:: python
 
   import intake
 
@@ -22,7 +26,9 @@ To load an Earth System Model (ESM) collection with `intake-esm <https://intake-
   col
 
 This gives a summary of the ESM collection, including the total number of Zarr data stores (referred to as assets), along with the total number of datasets these Zarr data stores correspond to.
-The collection can also be viewed as a `pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_::
+The collection can also be viewed as a `pandas DataFrame <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_:
+
+.. code-block:: python
 
   col.df.head()
 
@@ -57,7 +63,9 @@ Loading Datasets
 ----------------
 Once you've identified data assets of interest, you can load them into xarray dataset containers using intake-esm's ``to_dataset_dict()`` method.
 Invoking this method yields a Python dictionary of high-level aggregated xarray datasets.
-The logic for merging/concatenating the query results into datasets is provided in the input JSON file, under ``aggregation_control``::
+The logic for merging/concatenating the query results into datasets is provided in the input JSON file, under ``aggregation_control``:
+
+.. code-block:: json
 
   "aggregation_control": {
     "variable_column_name": "variable_id",
@@ -94,14 +102,18 @@ The logic for merging/concatenating the query results into datasets is provided 
   }
 
 Though these aggregation specifications are sufficient to merge individual data assets into xarray datasets, sometimes additional arguments must be provided depending on the format of the data assets.
-For example, Zarr-based assets can be loaded with the option ``consolidated=True``, which relies on a consolidated metadata file to describe the assets with minimal data egress::
+For example, Zarr-based assets can be loaded with the option ``consolidated=True``, which relies on a consolidated metadata file to describe the assets with minimal data egress:
+
+.. code-block:: python
 
   dsets = col_subset.to_dataset_dict(zarr_kwargs={'consolidated': True}, storage_options={'token': 'anon'})
 
   # list all merged datasets
   [key for key in dsets.keys()]
 
-When the datasets have finished loading, we can extract any of them like we would a value in a Python dictionary::
+When the datasets have finished loading, we can extract any of them like we would a value in a Python dictionary:
+
+.. code-block:: python
 
   ds = dsets['ScenarioMIP.THU.CIESM.ssp585.Amon.gr']
   ds

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,12 +13,14 @@ As part of the `AWS Public Dataset Program <https://aws.amazon.com/opendata/publ
 
 Requirements
 ------------
-Currently, the Zarr-formatted CMIP6 data is organized and accessed through an Earth System Model (ESM) collection, which can be opened and searched using intake-esm::
+Currently, the Zarr-formatted CMIP6 data is organized and accessed through an Earth System Model (ESM) collection, which can be opened and searched using intake-esm:
 
-    import intake
+.. code-block:: python
 
-    col = intake.open_esm_datastore("https://cmip6-pds.s3-us-west-2.amazonaws.com/pangeo-cmip6.json")
-    col
+  import intake
+
+  col = intake.open_esm_datastore("https://cmip6-pds.s3-us-west-2.amazonaws.com/pangeo-cmip6.json")
+  col
 
 Using intake-esm to open these datasets requires several other Python packages:
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -19,9 +19,11 @@ The keywords categorize the model data in the many ways we might want to search 
 For example, to find all available 3 hourly precipitation data from the pre-industrial control runs, we only need to specify the variable, frequency and experiment name.
 The modeling centers all agreed to use the same keywords, each with its own controlled vocabulary.
 In this case, the keywords ``['variable_id', 'table_id', 'experiment_id']`` will have the values ``['pr', '3hr', 'piControl']``.
-The data are structured in this cloud repository using 8 of these keywords in this order::
+The data are structured in this cloud repository using 8 of these keywords in this order:
 
-    cmip6/<activity_id>/<institution_id>/<source_id>/<experiment_id>/<member_id>/<table_id>/<variable_id>/<grid_label>/
+.. code-block:: python
+
+  cmip6/<activity_id>/<institution_id>/<source_id>/<experiment_id>/<member_id>/<table_id>/<variable_id>/<grid_label>/
 
 Each object specified in this way refers to a single Zarr data store.
 
@@ -30,8 +32,10 @@ Structure of the CSV File
 A master spreadsheet of all available data is stored in a `simple CSV file <https://storage.googleapis.com/cmip6/pangeo-cmip6.csv>`_ in which the first line consists of the column names and each subsequent line specifies a Zarr data store.
 The first 9 column names correspond to these 8 keywords, with an additional column for the URL of the Zarr data store.
 The last column is included in the master spreadsheet for convenience when using the DCPP-type of experiments.
-Here are the 10 columns::
+Here are the 10 columns:
 
-    activity_id  institution_id  source_id  experiment_id  member_id  table_id  variable_id  grid_label  zstore  dcpp_init_year
+.. code-block:: python
+
+  activity_id  institution_id  source_id  experiment_id  member_id  table_id  variable_id  grid_label  zstore  dcpp_init_year
 
 Although there are currently over 250,000 entries, this simple text file can be viewed in any spreadsheet application and the entries can be sorted, selected and discovered quickly and efficiently.


### PR DESCRIPTION
This adds the `code-block` directive to each code block in the RST files - this allows the flexibility of specifying what language each block is.