### PR TITLE
Add information for data access with other languages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,37 +1,38 @@
 Pangeo CMIP6
 ============
-This page will serve as a central hub for information on accessing and interacting with data from the Coupled Model Intercomparison Project Phase 6 (CMIP6) stored on Amazon Web Services (AWS) cloud storage, managed by Pangeo.
+This page will serve as a central hub for information on accessing and interacting with data from the Coupled Model Intercomparison Project Phase 6 (CMIP6) in cloud storage, managed by `Pangeo <https://pangeo.io/>`_.
 This data is formatted using `Zarr <https://zarr.readthedocs.io/en/stable/>`_, a cloud-optimized storage format.
-Interaction with the data is done primarily through Python, using `intake <https://intake.readthedocs.io/en/stable/>`_, `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, and `xarray <https://xarray.pydata.org/en/stable/>`_.
 
 Background
 ----------
 The Coupled Model Intercomparison Project (CMIP) is an international collaborative effort to improve the knowledge about climate change and its impacts on the Earth System and on our society.
 `CMIP began in 1995 <https://www.wcrp-climate.org/wgcm-cmip>`_, and is currently in its sixth phase (CMIP6).
 The CMIP6 data archive consists of data models created across approximately 30 working groups and 1,000 researchers investigating the urgent environmental problem of climate change, and will provide a wealth of information for the next Assessment Report (AR6) of the `Intergovernmental Panel on Climate Change <https://www.ipcc.ch/>`_ (IPCC).
-As part of the `AWS Public Dataset Program <https://aws.amazon.com/opendata/public-datasets/>`_, this data is now available on S3 cloud storage.
+As part of `Google Cloud Public Datasets <https://cloud.google.com/public-datasets>`_ and the `AWS Open Data Sponsorship Program <https://aws.amazon.com/opendata/public-datasets/>`_, this data is now available on Google Cloud and Amazon S3 storage.
 
 Requirements
 ------------
-Currently, the Zarr-formatted CMIP6 data is organized and accessed through an Earth System Model (ESM) collection, which can be opened and searched using intake-esm:
+First and foremost, a Zarr package is required to interact with the data stores; listed are languages with documented Zarr packages:
 
-.. code-block:: python
+- List
+- of
+- languages/projects
+- that
+- allow
+- zarr
+- support
 
-  import intake
+Additionally, a filesystem package for Google Cloud and/or S3 storage is required to access the files containing the datasets; some popular packages include:
 
-  col = intake.open_esm_datastore("https://cmip6-pds.s3-us-west-2.amazonaws.com/pangeo-cmip6.json")
-  col
+- should
+- we
+- list
+- FS packages
+- for all
+- Zarr langauges?
 
-Using intake-esm to open these datasets requires several other Python packages:
-
-- intake, the base catalog package which intake-esm is a driver for
-- xarray, which provides a container for the opened datasets
-- zarr, to handle the backend of the individual datastores
-
-Additionally, a filesystem library is required to access the files containing the datasets:
-
-- `gcsfs <https://gcsfs.readthedocs.io/en/latest/>`_ when accessing data in Google Cloud Storage
-- `s3fs <https://s3fs.readthedocs.io/en/latest/>`_ when accessing data in S3 Storage
+Though optional, a CSV-loading package allows for searching and filtering of the Zarr data stores, which are enumerated in CSV files located at the root of each cloud storage bucket.
+Python users are encouraged to use `intake <https://intake.readthedocs.io/en/stable/>`_, `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, and `xarray <https://xarray.pydata.org/en/stable/>`_, which facilitate the exploration and use of the data through the use of Earth System Model (ESM) collection specifications which are also provided at the root of each bucket.
 
 Documentation
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,23 +12,21 @@ As part of `Google Cloud Public Datasets <https://cloud.google.com/public-datase
 
 Requirements
 ------------
-First and foremost, a Zarr package is required to interact with the data stores; listed are languages with Zarr packages with active development:
+First and foremost, a Zarr package is required to interact with the data stores.
+Listed below are languages with actively developed Zarr packages; bolded languages have Zarr packages that support reading of remote data stores:
 
-- Python: `zarr-developers/zarr-python <https://github.com/zarr-developers/zarr-python>`_
-- TypeScript: `gzuidhof/zarr.js <https://github.com/gzuidhof/zarr.js/>`_
+- **Python**: `zarr-developers/zarr-python <https://github.com/zarr-developers/zarr-python>`_
+- **TypeScript**: `gzuidhof/zarr.js <https://github.com/gzuidhof/zarr.js/>`_
 - C++: `constantinpape/z5 <https://github.com/constantinpape/z5>`_
-- Julia: `meggart/zarr.jl <https://github.com/meggart/Zarr.jl>`_
+- **Julia**: `meggart/zarr.jl <https://github.com/meggart/Zarr.jl>`_
 - Java: `saalfeldlab/n5-zarr <https://github.com/saalfeldlab/n5-zarr>`_
-- Scala: `lasersonlab/ndarray.scala <https://github.com/lasersonlab/ndarray.scala>`_
-- C: `Unidata/netcdf-c/libnczarr <https://github.com/Unidata/netcdf-c/tree/master/libnczarr>`_
+- **Scala**: `lasersonlab/ndarray.scala <https://github.com/lasersonlab/ndarray.scala>`_
+- **C**: `Unidata/netcdf-c/libnczarr <https://github.com/Unidata/netcdf-c/tree/master/libnczarr>`_
 
-Additionally, a filesystem package for Google Cloud and/or S3 storage is required for some languages to access the files containing the datasets:
+Additionally, a filesystem package for Google Cloud and/or S3 storage is required for some languages to access the files containing the data stores:
 
 - Python: `gcsfs <https://gcsfs.readthedocs.io/en/latest/>`_ or `s3fs <https://s3fs.readthedocs.io/en/latest/>`_
 - Julia: `AWSCore <https://github.com/JuliaCloud/AWSCore.jl>`_
-- Java: `saalfeldlab/n5-zarr <https://github.com/saalfeldlab/n5-zarr>`_
-- Scala: `lasersonlab/ndarray.scala <https://github.com/lasersonlab/ndarray.scala>`_
-- C: `Unidata/netcdf-c/libnczarr <https://github.com/Unidata/netcdf-c/tree/master/libnczarr>`_
 
 Though optional, a CSV-loading package allows for searching and filtering of the Zarr data stores, which are enumerated in CSV files located at the root of each cloud storage bucket.
 Python users are encouraged to use `intake <https://intake.readthedocs.io/en/stable/>`_, `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, and `xarray <https://xarray.pydata.org/en/stable/>`_, which facilitate the exploration and use of the data through the use of Earth System Model (ESM) collection specifications which are also provided at the root of each bucket.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Additionally, a filesystem package for Google Cloud and/or S3 storage is require
 - Julia: `AWSCore <https://github.com/JuliaCloud/AWSCore.jl>`_
 
 Though optional, a CSV-loading package allows for searching and filtering of the Zarr data stores, which are enumerated in CSV files located at the root of each cloud storage bucket.
-Python users are encouraged to use `intake <https://intake.readthedocs.io/en/stable/>`_, `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, and `xarray <https://xarray.pydata.org/en/stable/>`_, which facilitate the exploration and use of the data through the use of Earth System Model (ESM) collection specifications which are also provided at the root of each bucket.
+Python users are encouraged to use `xarray <https://xarray.pydata.org/en/stable/>`_, `intake <https://intake.readthedocs.io/en/stable/>`_, and `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, which facilitate exploration and interaction with the data through the use of Earth System Model (ESM) collection specifications which are also provided at the root of each bucket.
 
 Documentation
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,24 +12,23 @@ As part of `Google Cloud Public Datasets <https://cloud.google.com/public-datase
 
 Requirements
 ------------
-First and foremost, a Zarr package is required to interact with the data stores; listed are languages with documented Zarr packages:
+First and foremost, a Zarr package is required to interact with the data stores; listed are languages with Zarr packages with active development:
 
-- List
-- of
-- languages/projects
-- that
-- allow
-- zarr
-- support
+- Python: `zarr-developers/zarr-python <https://github.com/zarr-developers/zarr-python>`_
+- TypeScript: `gzuidhof/zarr.js <https://github.com/gzuidhof/zarr.js/>`_
+- C++: `constantinpape/z5 <https://github.com/constantinpape/z5>`_
+- Julia: `meggart/zarr.jl <https://github.com/meggart/Zarr.jl>`_
+- Java: `saalfeldlab/n5-zarr <https://github.com/saalfeldlab/n5-zarr>`_
+- Scala: `lasersonlab/ndarray.scala <https://github.com/lasersonlab/ndarray.scala>`_
+- C: `Unidata/netcdf-c/libnczarr <https://github.com/Unidata/netcdf-c/tree/master/libnczarr>`_
 
-Additionally, a filesystem package for Google Cloud and/or S3 storage is required to access the files containing the datasets; some popular packages include:
+Additionally, a filesystem package for Google Cloud and/or S3 storage is required for some languages to access the files containing the datasets:
 
-- should
-- we
-- list
-- FS packages
-- for all
-- Zarr langauges?
+- Python: `gcsfs <https://gcsfs.readthedocs.io/en/latest/>`_ or `s3fs <https://s3fs.readthedocs.io/en/latest/>`_
+- Julia: `AWSCore <https://github.com/JuliaCloud/AWSCore.jl>`_
+- Java: `saalfeldlab/n5-zarr <https://github.com/saalfeldlab/n5-zarr>`_
+- Scala: `lasersonlab/ndarray.scala <https://github.com/lasersonlab/ndarray.scala>`_
+- C: `Unidata/netcdf-c/libnczarr <https://github.com/Unidata/netcdf-c/tree/master/libnczarr>`_
 
 Though optional, a CSV-loading package allows for searching and filtering of the Zarr data stores, which are enumerated in CSV files located at the root of each cloud storage bucket.
 Python users are encouraged to use `intake <https://intake.readthedocs.io/en/stable/>`_, `intake-esm <https://intake-esm.readthedocs.io/en/stable/>`_, and `xarray <https://xarray.pydata.org/en/stable/>`_, which facilitate the exploration and use of the data through the use of Earth System Model (ESM) collection specifications which are also provided at the root of each bucket.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,19 +1,27 @@
 Cloud data overview
 ===================
+CMIP6 data in the cloud can be found in both Google Cloud and S3 storage buckets:
+
+- ``gs://cmip6``
+- ``s3://cmip6-pds``
+
+The data is primarily Zarr-formatted, with a predetermined and well-defined directory structure to ensure that it is properly organized and classified.
+This directory structure is reflected in the master CSV files located at the root of each bucket, which enumerates all available Zarr stores using their containing directory names as columns to allow for sorting and filtering.
+
 Zarr storage format
 -------------------
 We have chosen the `Zarr object model and storage format <https://zarr.readthedocs.io/en/stable/>`_ for our cloud-based data repositories.
 Each Zarr data store in the CMIP6 collection consists of all of the data, including the grids and metadata, stored in Zarr format.
 This format stores the data as a collection of files consisting of regular text files containing metadata and data files consisting of the data divided into compressed chunks which can be read individually or in parallel, allowing very large datasets to scale more efficiently in the cloud.
 
-The original datasets, stored in the WCRP/CMIP6 ESGF repositories, consists of `netCDF <https://www.unidata.ucar.edu/software/netcdf/>`_ files.
+The original datasets, stored in the WCRP/CMIP6 ESGF repositories, consist of `netCDF <https://www.unidata.ucar.edu/software/netcdf/>`_ files.
 Each of these datasets typically corresponds to a single variable saved at specified time intervals for the length of a single model run.
 For convenience, these datasets were often divided into multiple netCDF files.
 Our Zarr data stores correspond to the result of concatenating these netCDF files and then storing them as a single Zarr object.
 All of the metadata in the original netCDF files has been preserved, including the licensing information and the CMIP6 persistent identifiers (``tracking_ids``) which are unique for each of the original netCDF files.
 
-Directory layout
-----------------
+Directory structure
+-------------------
 To organize the data there is a list of keywords, each with a `controlled vocabulary <https://github.com/WCRP-CMIP/CMIP6_CVs>`_ which has been developed over the many CMIP iterations.
 The keywords categorize the model data in the many ways we might want to search the data.
 For example, to find all available 3 hourly precipitation data from the pre-industrial control runs, we only need to specify the variable, frequency and experiment name.
@@ -21,7 +29,7 @@ The modeling centers all agreed to use the same keywords, each with its own cont
 In this case, the keywords ``['variable_id', 'table_id', 'experiment_id']`` will have the values ``['pr', '3hr', 'piControl']``.
 The data are structured in this cloud repository using 8 of these keywords in this order::
 
-  cmip6/
+  cmip6[-pds]/
   └──<activity_id>/
       └──<institution_id>/
           └──<source_id>/
@@ -35,10 +43,14 @@ Each object specified in this way refers to a single Zarr data store.
 
 CSV file structure
 ------------------
-A master spreadsheet of all available data is stored in a `simple CSV file <https://storage.googleapis.com/cmip6/pangeo-cmip6.csv>`_ in which the first line consists of the column names and each subsequent line specifies a Zarr data store.
+Master CSV files enumerating all available Zarr data stores are located at the root of each bucket, and are available for download:
+
+- https://storage.googleapis.com/cmip6/cmip6-zarr-consolidated-stores.csv
+- https://cmip6-pds.s3-us-west-2.amazonaws.com/cmip6-zarr-consolidated-stores.csv
+
 The first 8 column names correspond to the standard CMIP keywords; the two additional columns are:
 
 - ``zstore``: the URL of the corresponding Zarr data store
 - ``dcpp_init_year``: optional metadata for convenience when accessing `DCPP <https://www.wcrp-climate.org/dcp-overview>`_-type experiments
 
-Although there are currently over 250,000 entries, this text file can be viewed in any spreadsheet application and the entries can be sorted, selected and discovered quickly and efficiently.
+Although there are currently over 250,000 entries, these files can be viewed in any spreadsheet application and the entries can be sorted, selected and discovered quickly and efficiently.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -24,8 +24,7 @@ Directory structure
 -------------------
 To organize the data there is a list of keywords, each with a `controlled vocabulary <https://github.com/WCRP-CMIP/CMIP6_CVs>`_ which has been developed over the many CMIP iterations.
 The keywords categorize the model data in the many ways we might want to search the data.
-For example, to find all available 3 hourly precipitation data from the pre-industrial control runs, we only need to specify the variable, frequency and experiment name.
-The modeling centers all agreed to use the same keywords, each with its own controlled vocabulary.
+For example, to find all available 3-hourly precipitation data from the pre-industrial control runs, we only need to specify the variable, frequency and experiment name.
 In this case, the keywords ``['variable_id', 'table_id', 'experiment_id']`` will have the values ``['pr', '3hr', 'piControl']``.
 The data are structured in this cloud repository using 8 of these keywords in this order::
 
@@ -43,14 +42,38 @@ Each object specified in this way refers to a single Zarr data store.
 
 CSV file structure
 ------------------
-Master CSV files enumerating all available Zarr data stores are located at the root of each bucket, and are available for download:
+There are two different master CSV files enumerating available Zarr data stores located at the root of each bucket; one contains only datasets with no serious issues listed in the official `ESGF Errata Service <https://errata.es-doc.org/static/index.html>`_:
 
 - https://storage.googleapis.com/cmip6/cmip6-zarr-consolidated-stores.csv
 - https://cmip6-pds.s3-us-west-2.amazonaws.com/cmip6-zarr-consolidated-stores.csv
 
-The first 8 column names correspond to the standard CMIP keywords; the two additional columns are:
+The other contains all available Zarr data stores, including those with serious issues (represented with a ``-noQC`` label):
 
-- ``zstore``: the URL of the corresponding Zarr data store
+- https://storage.googleapis.com/cmip6/cmip6-zarr-consolidated-stores-noQC.csv
+- https://cmip6-pds.s3-us-west-2.amazonaws.com/cmip6-zarr-consolidated-stores-noQC.csv
+
+The first 8 column names correspond to the standard CMIP keywords; the next three additional columns are:
+
+- ``zstore``: URL of the corresponding Zarr data store
 - ``dcpp_init_year``: optional metadata for convenience when accessing `DCPP <https://www.wcrp-climate.org/dcp-overview>`_-type experiments
+- ``version``: dataset version listed on ESGF in YYYYMMDD format
+
+Finally, the ``-noQC`` variants exclusively include three additional columns:
+
+- ``status``: status of the dataset's issue, if any, using a controlled vocabulary:
+
+  - ``new``: TODO
+  - ``onhold``: TODO
+  - ``resolved``: issue has been resolved AND the corrected files have been published on ESGF with a new dataset version
+  - ``wontfix``: issue cannot/won’t be fixed by the data provider; may result in a persistent low severity issue with no consequences to analysis
+
+- ``severity``: severity of the dataset's issue, if any, using a controlled vocabulary:
+
+  - ``low``: issue concerns file management (e.g., addition, removal, period extension, etc.)
+  - ``medium``: issue concerns metadata (netCDF attributes) without undermining the values of the involved variable
+  - ``high``: issue concerns single point variable or axis values
+  - ``critical``: issue concerns the variable or axis values undermining the analysis; use of this data is strongly discouraged
+
+- ``issue_url``: link to view the issue on ESGF Errata Service
 
 Although there are currently over 250,000 entries, these files can be viewed in any spreadsheet application and the entries can be sorted, selected and discovered quickly and efficiently.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -5,13 +5,12 @@ CMIP6 data in the cloud can be found in both Google Cloud and S3 storage buckets
 - ``gs://cmip6``
 - ``s3://cmip6-pds``
 
-The data is primarily Zarr-formatted, with a predetermined and well-defined directory structure to ensure that it is properly organized and classified.
+The data is primarily `Zarr <https://zarr.readthedocs.io/en/stable/>`_-formatted, with a predetermined and well-defined directory structure to ensure that it is properly organized and classified.
 This directory structure is reflected in the master CSV files located at the root of each bucket, which enumerates all available Zarr stores using their containing directory names as columns to allow for sorting and filtering.
 
 Zarr storage format
 -------------------
-We have chosen the `Zarr object model and storage format <https://zarr.readthedocs.io/en/stable/>`_ for our cloud-based data repositories.
-Each Zarr data store in the CMIP6 collection consists of all of the data, including the grids and metadata, stored in Zarr format.
+Each data store in the CMIP6 collection consists of all of the data, including the grids and metadata, stored in Zarr format.
 This format stores the data as a collection of files consisting of regular text files containing metadata and data files consisting of the data divided into compressed chunks which can be read individually or in parallel, allowing very large datasets to scale more efficiently in the cloud.
 
 The original datasets, stored in the WCRP/CMIP6 ESGF repositories, consist of `netCDF <https://www.unidata.ucar.edu/software/netcdf/>`_ files.


### PR DESCRIPTION
As discussed in #14, we don't want to alienate non-Python users with documentation that pushes Python as the primary means of data access. This overhauls parts of the documentation to add information about other languages that can be used to access Zarr data, their individual requirements, and maybe in time some code snippets with examples of their functionality.

One major aspect of this overhaul is a list of all documented Zarr packages for non-Python languages; @andersy005, I recall this being a part of your Zarr presentation at the STAC sprint, is there anywhere I can access your slides or this list?