### PR TITLE
update to current XarrayZarrRecipe store API

### DIFF
--- a/zarr_from_esgf.py
+++ b/zarr_from_esgf.py
@@ -93,21 +93,6 @@ recipe = XarrayZarrRecipe(
     xarray_concat_kwargs={"join": "exact"},
 )
 
-fs_local = LocalFileSystem()
-
-target_dir = tempfile.TemporaryDirectory().name + ".zarr"
-target = FSSpecTarget(fs_local, target_dir)
-
-cache_dir = tempfile.TemporaryDirectory()
-cache_target = CacheFSSpecTarget(fs_local, cache_dir.name)
-
-meta_dir = tempfile.TemporaryDirectory()
-meta_store = MetadataTarget(fs_local, meta_dir.name)
-
-recipe.target = target
-recipe.input_cache = cache_target
-recipe.metadata_cache = meta_store
-
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
     level=logging.INFO,
@@ -119,4 +104,4 @@ logger.setLevel(logging.INFO)
 
 recipe.to_function()()
 
-print(target_dir)
+print(recipe.target)


### PR DESCRIPTION
Just tried this out and had to make a few changes (consistent with our conversation yesterday @jbusecke) to get the cache & target store setup to work:
* Directly assigning target is no longer supported
* temporary local stores are created by default

I'm still a bit unclear on how to specify a fs target other than the default tmp store, but this should run the same way as the previous script.
