### PR TITLE
Reactivate Retraction Logic

### DIFF
--- a/create_filtered_catalog.py
+++ b/create_filtered_catalog.py
@@ -11,15 +11,14 @@ gcs = gcsfs.GCSFileSystem()
 catalog_url = "https://cmip6.storage.googleapis.com/pangeo-cmip6.csv"
 node_urls = [
 "https://esgf-node.llnl.gov/esg-search/search",
-"https://esgf-data.dkrz.de/esg-search/search",
-"https://esgf-index1.ceda.ac.uk/esg-search/search",
-"https://esgf-node.ipsl.upmc.fr/esg-search/search",
+# "https://esgf-data.dkrz.de/esg-search/search",
+# "https://esgf-index1.ceda.ac.uk/esg-search/search",
+# "https://esgf-node.ipsl.upmc.fr/esg-search/search",
 ]
 
 params = {
     "type": "Dataset",
     "mip_era": "CMIP6",
-    "replica": "false",
     "distrib": "true",
     "retracted": "true",
     "format": "application/solr+json",
@@ -28,7 +27,7 @@ params = {
 # query every one of the nodes
 retracted_ids = {
      url.split('.')[1] :query_retraction_retry(
-        url, params, batchsize=10000
+        url, params, batchsize=5000
     ) for url in node_urls
 }
 


### PR DESCRIPTION
I just got access to the public bucket back, and that seems to work. [This job](https://github.com/pangeo-data/pangeo-cmip6-cloud/actions/runs/7203999653) still fails, but it is not because the authentication!

In this PR I am applying a few things that I have learned over the past. 

1) The `replica` keyword for the ESGF query is quite confusing to me. Writing this I wrongly assumed that setting this to false I would only get the results for all the (distributed) master records, but after my recent experience I am not so sure about that. According to [the ESGF API repo](https://github.com/pangeo-data/pangeo-cmip6-cloud/actions/runs/7203999653) I believe just leaving this as the default it the way to go. 

[That last job timed out](https://github.com/pangeo-data/pangeo-cmip6-cloud/actions/runs/7203999653) because it would time out for the dkrz node, so I am deactivating that for now. 